### PR TITLE
Fixed Capitalization in ServiceProvider reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ composer require smoothphp/cqrs-es-framework-laravel
 ```
 
 ``` php
-SmoothPHP\LaravelAdapter\ServiceProvider::class,
+SmoothPhp\LaravelAdapter\ServiceProvider::class,
 
 ```
 


### PR DESCRIPTION
Reference to ServiceProvider was pointing to SmoothPHP and not SmoothPhp which was causing a class not found exception
