### PR TITLE
[Service Provider] Check ES enabled before adding projection command

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -51,16 +51,18 @@ final class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $this->registerEventDispatcher($app);
         $this->registerEventBus($app);
 
-        $this->commands(
-            [
-                BuildLaravelEventStore::class,
-                RebuildProjectionsCommand::class,
-                EventStoreBranchSwap::class,
-                ExportEventStore::class,
-                ImportEventStore::class,
-                RunProjectionCommand::class,
-            ]
-        );
+        if ($app['config']->get('cqrses.laravel_eventstore_enabled')) {
+            $this->commands(
+                [
+                    BuildLaravelEventStore::class,
+                    RebuildProjectionsCommand::class,
+                    EventStoreBranchSwap::class,
+                    ExportEventStore::class,
+                    ImportEventStore::class,
+                    RunProjectionCommand::class,
+                ]
+            );
+        }
 
     }
 


### PR DESCRIPTION
### Before:

`RunProjectionsCommand` would still be registered as a command, causing an error if event store not enabled

### After
`RunProjectionsCommand` only enabled if eventstore enabled